### PR TITLE
fix: prevent ClassCastException

### DIFF
--- a/src/main/java/com/camunda/academy/handler/CreditCardServiceHandler.java
+++ b/src/main/java/com/camunda/academy/handler/CreditCardServiceHandler.java
@@ -28,7 +28,7 @@ public class CreditCardServiceHandler implements JobHandler {
     	//Obtain the Process Variables
     	final Map<String, Object> inputVariables = job.getVariablesAsMap();
     	final String reference = (String) inputVariables.get(VARIABLE_REFERENCE);
-    	final Double amount = (Double) inputVariables.get(VARIABLE_AMOUNT);
+		final Double amount = ((Number) inputVariables.get(VARIABLE_AMOUNT)).doubleValue();
     	final String cardNumber = (String) inputVariables.get(VARIABLE_CARD_NUMBER);
     	final String cardExpiry = (String) inputVariables.get(VARIABLE_CARD_EXPIRY);
     	final String cardCVC =  (String) inputVariables.get(VARIABLE_CARD_CVC);


### PR DESCRIPTION
## Description

It is not sure that "amount" is actually a `Double`. We can safely assume that this is a `Number`. By casting it to a `Number` and getting the `doubleValue` we can prevent a `ClassCastException` here.

closes #1 